### PR TITLE
fix(operation): return tuple-like array in select_team

### DIFF
--- a/src/operation.js
+++ b/src/operation.js
@@ -12,11 +12,11 @@ function select_team(team) {
     name = '寶島夢想家';
     games = dreamerGames;
   }
-  return name, games;
+  return [name, games];
 }
 async function find_next_game_by_team(context, name) {
   let now = moment().format('YYYY-MM-DD HH:mm');
-  let team, games = select_team(name);
+  let [team, games] = select_team(name);
   // next game
   for (let index = 0; index < games.length; index++) {
     const el = games[index];
@@ -33,7 +33,7 @@ async function find_next_game_by_team(context, name) {
 
 async function find_current_game(context, name) {
   let now = moment().format('YYYY-MM-DD');
-  let team, games = select_team(name);
+  let [team, games] = select_team(name);
   let today = true;
   for (let index = 0; index < games.length; index++) {
     const el = games[index];


### PR DESCRIPTION
先猜原本的寫法會有問題 

https://developer.mozilla.org/zh-TW/docs/Web/JavaScript/Reference/Operators/Comma_Operator

在 js 我們很少用 a, b 這樣的寫法 (會 return b 的 value)

這邊改最少的做法是用 array 來當假 tuple，不過這種寫法比較少見，回傳 object 比較常見：

```js
return { name, games };
```

但這樣在 destructuring 時要做一個 rename:

```js
const { name: team, games } = select_team(name);
```